### PR TITLE
typos

### DIFF
--- a/curve-curvature-new.tex
+++ b/curve-curvature-new.tex
@@ -77,7 +77,7 @@ Therefore,
 \left|\frac{d\tan}{ dt}\right|/\left|\frac{ds}{ dt}\right|=
 \frac{|\tan'|}{|\gamma'|}.
 \end{align*}
-It follows that \textit{if the curvature of a smooth curve $\gamma$ does not vanish, then its tangent indicatrix is a smooth curve}; see \ref{sec:Smooth curves}.
+It follows that \textit{if the velocity vector of a smooth curve $\gamma$ does not vanish, then its tangent indicatrix is a smooth curve}; see \ref{sec:Smooth curves}.
 
 \begin{thm}{Exercise}\label{ex:curvature-formulas}
 Use the formulas \ref{eq:tantrix} and \ref{eq:curvature} to show that 

--- a/sol-new.tex
+++ b/sol-new.tex
@@ -1501,7 +1501,7 @@ A body bounded by a sphere must include a ball of radius a bit larger than $r_3=
 \parbf{\ref{ex:supp>tan}.}
 We may assume that $\Sigma_1$ is given implicitly by a smooth function $f$ in a small neighborhood $U$ of $p$.
 Since $\Sigma_1$ locally supports $\Sigma_2$ at $p$, we may assume that $f(x)\ge 0$ for all $x\in \Sigma_2\cap U$
-and that $f |_{\Sigma _2 \cap U} \equiv 0$.
+and that $f |_{\Sigma_1 \cap U} \equiv 0$.
 
 Show that $(f\circ\gamma_2)'(0)=0$ for any smooth curve $\gamma_2\:(-\varepsilon,\varepsilon)\to\Sigma_2$ such that $\gamma_2(0)=p$.
 Deduce from this that the velocity vector $\gamma_2'(0)$ is tangent to $\Sigma_1$ at $p$ and make the last step.

--- a/sol-new.tex
+++ b/sol-new.tex
@@ -1501,7 +1501,7 @@ A body bounded by a sphere must include a ball of radius a bit larger than $r_3=
 \parbf{\ref{ex:supp>tan}.}
 We may assume that $\Sigma_1$ is given implicitly by a smooth function $f$ in a small neighborhood $U$ of $p$.
 Since $\Sigma_1$ locally supports $\Sigma_2$ at $p$, we may assume that $f(x)\ge 0$ for all $x\in \Sigma_2\cap U$
-and that $f(p)=0$.
+and that $f |_{\Sigma _2 \cap U} \equiv 0$.
 
 Show that $(f\circ\gamma_2)'(0)=0$ for any smooth curve $\gamma_2\:(-\varepsilon,\varepsilon)\to\Sigma_2$ such that $\gamma_2(0)=p$.
 Deduce from this that the velocity vector $\gamma_2'(0)$ is tangent to $\Sigma_1$ at $p$ and make the last step.


### PR DESCRIPTION
f defines Sigma_1 implicitly, so f is identically 0 in Sigma_1, not just at p.